### PR TITLE
Added OpenIPAM integration for DNS record creation

### DIFF
--- a/acme-dns-auth.py
+++ b/acme-dns-auth.py
@@ -4,7 +4,7 @@ import os
 import requests
 import sys
 
-### EDIT THESE: Configuration values ###
+# EDIT THESE: Configuration values #
 
 # URL to acme-dns instance
 ACMEDNS_URL = "https://acmedns.usu.edu"
@@ -16,68 +16,73 @@ ALLOW_FROM = ["129.123.0.0/16", "144.39.0.0/16"]
 # Force re-registration. Overwrites the already existing acme-dns accounts.
 FORCE_REGISTER = False
 
-###   DO NOT EDIT BELOW THIS POINT   ###
-###         HERE BE DRAGONS          ###
+#   DO NOT EDIT BELOW THIS POINT   #
+#         HERE BE DRAGONS          #
 
 DOMAIN = os.environ["CERTBOT_DOMAIN"]
 if DOMAIN.startswith("*."):
     DOMAIN = DOMAIN[2:]
-VALIDATION_DOMAIN = "_acme-challenge."+DOMAIN
+VALIDATION_DOMAIN = "_acme-challenge." + DOMAIN
 VALIDATION_TOKEN = os.environ["CERTBOT_VALIDATION"]
 
 
 class AcmeDnsClient(object):
-    """
-    Handles the communication with ACME-DNS API
-    """
+    """Handles the communication with ACME-DNS API."""
 
     def __init__(self, acmedns_url):
         self.acmedns_url = acmedns_url
 
     def register_account(self, allowfrom):
-        """Registers a new ACME-DNS account"""
-
+        """Register a new ACME-DNS account."""
         if allowfrom:
             # Include whitelisted networks to the registration call
             reg_data = {"allowfrom": allowfrom}
-            res = requests.post(self.acmedns_url+"/register",
-                                data=json.dumps(reg_data))
+            res = requests.post(
+                self.acmedns_url + "/register", data=json.dumps(reg_data)
+            )
         else:
-            res = requests.post(self.acmedns_url+"/register")
+            res = requests.post(self.acmedns_url + "/register")
         if res.status_code == 201:
             # The request was successful
             return res.json()
         else:
             # Encountered an error
-            msg = ("Encountered an error while trying to register a new acme-dns "
-                   "account. HTTP status {}, Response body: {}")
+            msg = (
+                "Encountered an error while trying to register a new acme-dns "
+                "account. HTTP status {}, Response body: {}"
+            )
             print(msg.format(res.status_code, res.text))
             sys.exit(1)
 
     def update_txt_record(self, account, txt):
-        """Updates the TXT challenge record to ACME-DNS subdomain."""
-        update = {"subdomain": account['subdomain'], "txt": txt}
-        headers = {"X-Api-User": account['username'],
-                   "X-Api-Key": account['password'],
-                   "Content-Type": "application/json"}
-        res = requests.post(self.acmedns_url+"/update",
-                            headers=headers,
-                            data=json.dumps(update))
+        """Update the TXT challenge record to ACME-DNS subdomain."""
+        update = {"subdomain": account["subdomain"], "txt": txt}
+        headers = {
+            "X-Api-User": account["username"],
+            "X-Api-Key": account["password"],
+            "Content-Type": "application/json",
+        }
+        res = requests.post(
+            self.acmedns_url + "/update", headers=headers, data=json.dumps(update)
+        )
         if res.status_code == 200:
             # Successful update
             return
         else:
-            msg = ("Encountered an error while trying to update TXT record in "
-                   "acme-dns. \n"
-                   "------- Request headers:\n{}\n"
-                   "------- Request body:\n{}\n"
-                   "------- Response HTTP status: {}\n"
-                   "------- Response body: {}")
+            msg = (
+                "Encountered an error while trying to update TXT record in "
+                "acme-dns. \n"
+                "------- Request headers:\n{}\n"
+                "------- Request body:\n{}\n"
+                "------- Response HTTP status: {}\n"
+                "------- Response body: {}"
+            )
             s_headers = json.dumps(headers, indent=2, sort_keys=True)
             s_update = json.dumps(update, indent=2, sort_keys=True)
             s_body = json.dumps(res.json(), indent=2, sort_keys=True)
             print(msg.format(s_headers, s_update, res.status_code, s_body))
             sys.exit(1)
+
 
 class Storage(object):
     def __init__(self, storagepath):
@@ -85,11 +90,11 @@ class Storage(object):
         self._data = self.load()
 
     def load(self):
-        """Reads the storage content from the disk to a dict structure"""
+        """Read the storage content from the disk to a dict structure."""
         data = dict()
         filedata = ""
         try:
-            with open(self.storagepath, 'r') as fh:
+            with open(self.storagepath, "r") as fh:
                 filedata = fh.read()
         except IOError as e:
             if os.path.isfile(self.storagepath):
@@ -106,11 +111,12 @@ class Storage(object):
         return data
 
     def save(self):
-        """Saves the storage content to disk"""
+        """Save the storage content to disk."""
         serialized = json.dumps(self._data)
         try:
-            with os.fdopen(os.open(self.storagepath,
-                                   os.O_WRONLY | os.O_CREAT, 0o600), 'w') as fh:
+            with os.fdopen(
+                os.open(self.storagepath, os.O_WRONLY | os.O_CREAT, 0o600), "w"
+            ) as fh:
                 fh.truncate()
                 fh.write(serialized)
         except IOError as e:
@@ -118,7 +124,7 @@ class Storage(object):
             sys.exit(1)
 
     def put(self, key, value):
-        """Puts the configuration value to storage and sanitize it"""
+        """Put the configuration value to storage and sanitize it."""
         # If wildcard domain, remove the wildcard part as this will use the
         # same validation record name as the base domain
         if key.startswith("*."):
@@ -126,11 +132,12 @@ class Storage(object):
         self._data[key] = value
 
     def fetch(self, key):
-        """Gets configuration value from storage"""
+        """Get configuration value from storage."""
         try:
             return self._data[key]
         except KeyError:
             return None
+
 
 if __name__ == "__main__":
     # Init
@@ -145,10 +152,35 @@ if __name__ == "__main__":
         storage.put(DOMAIN, account)
         storage.save()
 
-        # Display the notification for the user to update the main zone
-        msg = "Please add the following CNAME record to your main DNS zone:\n{}"
-        cname = "{} CNAME {}.".format(VALIDATION_DOMAIN, account["fulldomain"])
-        print(msg.format(cname))
+        # TODO: Add OpenIPAM integration for automatic DNS record creation
+        openipam_url = os.environ.get("OPENIPAM_URL", "https://openipam.usu.edu")
+        auth_token = os.environ.get("OPENIPAM_TOKEN")
+        if auth_token:
+            try:
+                res = requests.post(
+                    f"{openipam_url}/api/dns/add/",
+                    data={
+                        "name": VALIDATION_DOMAIN,
+                        "dns_type": "CNAME",
+                        "content": account["fulldomain"],
+                    },
+                    headers={
+                        "Authorization": f"Token {auth_token}",
+                    },
+                )
+                if res.status_code != 201:
+                    raise Exception(f"Failed to add DNS record: {res.text}")
+            except Exception as e:
+                print(f"Error: {e}")
+                print("Unable to create DNS record automatically.")
+                msg = "Please add the following CNAME record to your main DNS zone:\n{}"
+                cname = "{} CNAME {}.".format(VALIDATION_DOMAIN, account["fulldomain"])
+                print(msg.format(cname))
+        else:
+            # Display the notification for the user to update the main zone
+            msg = "Please add the following CNAME record to your main DNS zone:\n{}"
+            cname = "{} CNAME {}.".format(VALIDATION_DOMAIN, account["fulldomain"])
+            print(msg.format(cname))
 
     # Update the TXT record in acme-dns instance
     client.update_txt_record(account, VALIDATION_TOKEN)


### PR DESCRIPTION
Added the ability to automatically create CNAME records in OpenIPAM using an API token stored in the environment or configuration variable `OPENIPAM_TOKEN`. If this token is not present, or record creation fails, the script falls back to its original functionality of printing the requested CNAME record.